### PR TITLE
full RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -13,7 +13,7 @@ layout: null
         <title>{{ post.title | xml_escape }}</title>
         <description>
           {% if post.subtitle %}{{ post.subtitle | xml_escape }} - {% endif %}
-          {{ post.content | strip_html | xml_escape | truncatewords: 50 }}
+          {{ post.content | strip_html | xml_escape }}
         </description>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
         <link>{{ site.url }}{{ post.url }}</link>


### PR DESCRIPTION
The RSS feed that beautiful-jekyll generates is truncated on 50 words. I removed this restriction (so the posts are readable in RSS readers)